### PR TITLE
Unsorted require statements cause problems on some platforms

### DIFF
--- a/lib/zferral.rb
+++ b/lib/zferral.rb
@@ -3,7 +3,7 @@ require 'httparty'
 require 'json'
 require 'hashie'
 
-Dir[File.join(File.dirname(__FILE__), 'zferral', '**', '*.rb')].each {|f| require f}
+Dir[File.join(File.dirname(__FILE__), 'zferral', '**', '*.rb')].sort.each {|f| require f}
 
 module Zferral #:nodoc:
   # Creates a new API {Zferral::Client} with the passed arguments.


### PR DESCRIPTION
Discovered this today when I used your gem on an older Ubuntu system.  Sorting the Dir glob array fixed the problem.
